### PR TITLE
Docker update

### DIFF
--- a/dockersnpeff/Dockerfile
+++ b/dockersnpeff/Dockerfile
@@ -1,8 +1,11 @@
 FROM ubuntu:20.04
-LABEL maintener="romudock"
+LABEL maintener="Fabrice Besnard <fabrice.besnard@ens-lyon.fr>"
+LABEL repository="https://github.com/fabfabBesnard/Parallel-Variant-Calling/"
+LABEL description="Latest snpEff program coming with a few pre-built databases for popular model organisms in biology"
 
-WORKDIR .
-
+# Build a context directory (e.g.: https://newbedev.com/what-is-app-working-directory-for-a-dockerfile)
+WORKDIR /myapp
+# Change Shell to 'bash', default is 'sh'
 SHELL [ "/bin/bash", "-c" ]
 
 RUN apt-get -y update && \

--- a/dockersnpeff/Dockerfile
+++ b/dockersnpeff/Dockerfile
@@ -26,6 +26,6 @@ RUN cd snpEff && \
 	java -jar snpEff.jar download Drosophila_melanogaster &&\
 	java -jar snpEff.jar download Schizosaccharomyces_pombe
 
-RUN cp -r snpEff/scripts/* snpEff/exec/.
+RUN cp -r /myapp/snpEff/scripts/* /myapp/snpEff/exec/.
  
-ENV PATH=$PATH:/snpEff/exec/
+ENV PATH=$PATH:/myapp/snpEff/exec/

--- a/dockersnpeff/Dockerfile
+++ b/dockersnpeff/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get -y update && \
 
 RUN	wget "https://snpeff.blob.core.windows.net/versions/snpEff_latest_core.zip" && \
     unzip snpEff_latest_core.zip
-    
+
+# Install pre-built databases    
 RUN cd snpEff && \
 	java -jar snpEff.jar download Arabidopsis_thaliana && \
 	java -jar snpEff.jar download Physcomitrella_patens && \
@@ -26,6 +27,6 @@ RUN cd snpEff && \
 	java -jar snpEff.jar download Drosophila_melanogaster &&\
 	java -jar snpEff.jar download Schizosaccharomyces_pombe
 
-RUN cp -r /myapp/snpEff/scripts/* /myapp/snpEff/exec/.
- 
+# Add snpeff (or snpsift and all scripts) executable commands to the $PATH when the docker container is running
+RUN cp -r /myapp/snpEff/scripts/* /myapp/snpEff/exec/. 
 ENV PATH=$PATH:/myapp/snpEff/exec/

--- a/dockersnpeff/Readme.md
+++ b/dockersnpeff/Readme.md
@@ -58,7 +58,7 @@ docker build -t snpeff:latest . # should be run in this 'dockersnpeff' directory
 		`java -jar snpEff/snpEff.jar -version` # verify that snpEff command is working inside the container
 		`ls snpEff/data` # With the database downloads listed above, each species should have a dedicated folder, so the result should display this folder list: Arabidopsis_thaliana, Caenorhabditis_elegans, Physcomitrella_patens, Saccharomyces_cerevisiae, Zea_mays Caenorhabditis_briggsae, Drosophila_melanogaster, Populus_trichocarpa, Schizosaccharomyces_pombe. 
 
-! **Note 3**: Each folder contains a unique file called "snpEffectPredictor.bin"
+! **Note 3**: Each folder contains a unique file called `snpEffectPredictor.bin`
 
 To share and distribute you docker image, push your new docker image to dockerhub. You need a dockerhub account (Use Docker hub [documentation] (https://docs.docker.com/docker-hub/)). Then simply push your image on the distant dockerhub server, e.g.:
 	`docker push yourdockerhub_userid/snpeff:yourtag`

--- a/dockersnpeff/Readme.md
+++ b/dockersnpeff/Readme.md
@@ -53,10 +53,13 @@ docker build -t snpeff:latest . # should be run in this 'dockersnpeff' directory
 ! **note 1**: do not worry if the terminal prints "ERROR while connecting to ..." the species database: the database is correctly downloaded however.
 
 ! **note 2**: verify that the image has the right content by mounting the container and exploring its content interactively:
-		`docker image list` #your new image shoulde appear in the list
-		`docker run -it snpeff:latest bash` # if needed, replace snpeff:latest by correct image_name:tag. Your prompt should have changed with something like "root@9fa82673eb90:/myapp#", indciating that you are now in the image container
-		`java -jar snpEff/snpEff.jar -version` # verify that snpEff command is working inside the container
-		`ls snpEff/data` # With the database downloads listed above, each species should have a dedicated folder, so the result should display this folder list: Arabidopsis_thaliana, Caenorhabditis_elegans, Physcomitrella_patens, Saccharomyces_cerevisiae, Zea_mays Caenorhabditis_briggsae, Drosophila_melanogaster, Populus_trichocarpa, Schizosaccharomyces_pombe. 
+		`docker image list #your new image shoulde appear in the list `
+
+		`docker run -it snpeff:latest bash # if needed, replace snpeff:latest by correct image_name:tag. Your prompt should have changed with something like "root@9fa82673eb90:/myapp#", indicating that you are now in the image container`
+
+		`java -jar snpEff/snpEff.jar -version # verify that snpEff command is working inside the container`
+
+		`ls snpEff/data # With the database downloads listed above, each species should have a dedicated folder, so the result should display this folder list: Arabidopsis_thaliana, Caenorhabditis_elegans, Physcomitrella_patens, Saccharomyces_cerevisiae, Zea_mays Caenorhabditis_briggsae, Drosophila_melanogaster, Populus_trichocarpa, Schizosaccharomyces_pombe.`
 
 ! **Note 3**: Each folder contains a unique file called `snpEffectPredictor.bin`
 

--- a/dockersnpeff/Readme.md
+++ b/dockersnpeff/Readme.md
@@ -70,7 +70,7 @@ docker build -t snpeff:latest .
 	$:ls snpEff/data 
 *#comment: With the database downloads listed above, each species should have a dedicated folder, so the result should display this folder list: Arabidopsis_thaliana, Caenorhabditis_elegans, Physcomitrella_patens, Saccharomyces_cerevisiae, Zea_mays Caenorhabditis_briggsae, Drosophila_melanogaster, Populus_trichocarpa, Schizosaccharomyces_pombe*
 
-! **Note 3**: Each folder contains a unique file called `snpEffectPredictor.bin`
+/!\ **Note 3**: Each folder contains a unique file called `snpEffectPredictor.bin`
 
 To share and distribute your new docker image, push it to dockerhub. You need a dockerhub account (use Docker hub [documentation] (https://docs.docker.com/docker-hub/)). Then simply push your image on the distant dockerhub server, e.g.:
 

--- a/dockersnpeff/Readme.md
+++ b/dockersnpeff/Readme.md
@@ -51,11 +51,13 @@ Provided that Docker (tested for >v20.10.3) is installed on your system, build a
 docker build -t snpeff:latest . # should be run in this 'dockersnpeff' directory, so that by default Dockerfile is sourced here
 ```
 ! **note 1**: do not worry if the terminal prints "ERROR while connecting to ..." the species database: the database is correctly downloaded however.
+
 ! **note 2**: verify that the image has the right content by mounting the container and exploring its content interactively:
 		`docker image list` #your new image shoulde appear in the list
 		`docker run -it snpeff:latest bash` # if needed, replace snpeff:latest by correct image_name:tag. Your prompt should have changed with something like "root@9fa82673eb90:/myapp#", indciating that you are now in the image container
 		`java -jar snpEff/snpEff.jar -version` # verify that snpEff command is working inside the container
 		`ls snpEff/data` # With the database downloads listed above, each species should have a dedicated folder, so the result should display this folder list: Arabidopsis_thaliana, Caenorhabditis_elegans, Physcomitrella_patens, Saccharomyces_cerevisiae, Zea_mays Caenorhabditis_briggsae, Drosophila_melanogaster, Populus_trichocarpa, Schizosaccharomyces_pombe. 
+
 ! **Note 3**: Each folder contains a unique file called "snpEffectPredictor.bin"
 
 To share and distribute you docker image, push your new docker image to dockerhub. You need a dockerhub account (Use Docker hub [documentation] (https://docs.docker.com/docker-hub/)). Then simply push your image on the distant dockerhub server, e.g.:
@@ -64,6 +66,4 @@ To share and distribute you docker image, push your new docker image to dockerhu
 	! **note 2**: to be able to push, ensure you are connected to dockerhub: `docker login -u user_id -p <password>` (Use --password-stdin instead of -p to be more secure)
 
 
-Finally, edit the relevant profiles in the nextflow configuration file of your `Parallel-Variant-Calling` pipeline (in `script/nextflow.config`), to specify when you would like to use this new docker for snpEff:
-
-change this `container = "dockerhub_previous_userid/snpeff:latest"` to this `container = "YOURACCOUNTNAME/snpeff:latest"` (use find ctrl+F and replace)
+Finally, edit the relevant profiles in the nextflow configuration file of your `Parallel-Variant-Calling` pipeline (in `script/nextflow.config`), to specify when you would like to use this new docker for snpEff. Change this: `container = "dockerhub_previous_userid/snpeff:latest"` to this: `container = "YOURACCOUNTNAME/snpeff:latest"` (use find ctrl+F and replace).

--- a/dockersnpeff/Readme.md
+++ b/dockersnpeff/Readme.md
@@ -19,7 +19,7 @@ Nicotiana_attenuata                                         	Nicotiana_attenuata
 
 ```
 
-Once you have found an annotation build for your organism, carefully note the name of this organism in the snpeff database (warning: name could be different, you should always take the first name).
+Once you have found an annotation build for your organism, carefully note the name of this organism in the snpEff database (warning: name could be different, you should always take the first name).
 
 ```sh
 Database_name                                         	Species_name                                         	          	                              	https://snpeff.blob.core.windows.net/databases/v5_0/.....zip
@@ -46,9 +46,23 @@ RUN cd snpEff && \
 	java -jar snpEff.jar download Nicotiana_attenuata
 ```
 
-Save and create the docker with this command line (you should be in the docker directory) `docker build. -T snpeff: latest `
+Provided that Docker (tested for >v20.10.3) is installed on your system, build and save the docker image with this command line:
+```
+docker build -t snpeff:latest . # should be run in this 'dockersnpeff' directory, so that by default the Dockerfile is sourced here
+```
+	! *note 1*: do not worry if the terminal prints "ERROR while connecting to ..." the species database: the database is correctly downloaded however.
+	! *note 2*:* verify that the image has the right content by mounting the container and exploring its content interactively:
+		`docker image list` #your new image shoulde appear in the list
+		`docker run -it snpeff:latest bash` # if needed, replace snpeff:latest by correct image_name:tag. Your prompt should have changed with something like "root@9fa82673eb90:/myapp#", indciating that you are now in the image container
+		`java -jar snpEff/snpEff.jar -version` # verify that snpEff command is working inside the container
+		`ls snpEff/data` # With the database downloads listed above, each species should have a dedicated folder, so the result should be: Arabidopsis_thaliana     Caenorhabditis_elegans   Physcomitrella_patens  Saccharomyces_cerevisiae   Zea_mays
+Caenorhabditis_briggsae  Drosophila_melanogaster  Populus_trichocarpa    Schizosaccharomyces_pombe. Each folder contains a unique file called "snpEffectPredictor.bin"
+
+To share and distribute you docker image, push your new docker image to dockerhub. You need a dockerhub account (Use Docker hub [documentation] (https://docs.docker.com/docker-hub/)). Then simply push your image on the distant dockerhub server, e.g.:
+	`docker push yourdockerhub_userid/snpeff:yourtag`
+	! *note 1*: the names of your local and your distant repositories should match. You can change the name you give to the local repository at the build step with `docker tag local-image:tagname yourdockerhub_userid/snpeff:tagname`
+	! *note 2*: to be able to push, ensure you are connected to dockerhub: `docker login -u user_id -p <password>` (Use --password-stdin instead of -p to be more secure)
 
 
-Finally, you can create your dockerhub account and push your container to dockerhub. (Use Docker hub [documentation] (https://docs.docker.com/docker-hub/))
-Modify configuration file of your pipeline:
-Change this `container = "romudock/snpeff: latest"` to this `container = "YOURACCOUNTNAME/snpeff: latest"` (use find ctrl+F and replace)
+Finally, edit the relevant profiles in nextflow configuration file of your 'Parallel-Variant-Calling' pipeline (in script/nextflow.config), to specify when you would like to use this new docker for snpEff:
+Change this `container = "dockerhub_previous_userid/snpeff:latest"` to this `container = "YOURACCOUNTNAME/snpeff:latest"` (use find ctrl+F and replace)

--- a/dockersnpeff/Readme.md
+++ b/dockersnpeff/Readme.md
@@ -48,21 +48,22 @@ RUN cd snpEff && \
 
 Provided that Docker (tested for >v20.10.3) is installed on your system, build and save the docker image with this command line:
 ```
-docker build -t snpeff:latest . # should be run in this 'dockersnpeff' directory, so that by default the Dockerfile is sourced here
+docker build -t snpeff:latest . # should be run in this 'dockersnpeff' directory, so that by default Dockerfile is sourced here
 ```
-	! *note 1*: do not worry if the terminal prints "ERROR while connecting to ..." the species database: the database is correctly downloaded however.
-	! *note 2*:* verify that the image has the right content by mounting the container and exploring its content interactively:
+! **note 1**: do not worry if the terminal prints "ERROR while connecting to ..." the species database: the database is correctly downloaded however.
+! **note 2**: verify that the image has the right content by mounting the container and exploring its content interactively:
 		`docker image list` #your new image shoulde appear in the list
 		`docker run -it snpeff:latest bash` # if needed, replace snpeff:latest by correct image_name:tag. Your prompt should have changed with something like "root@9fa82673eb90:/myapp#", indciating that you are now in the image container
 		`java -jar snpEff/snpEff.jar -version` # verify that snpEff command is working inside the container
-		`ls snpEff/data` # With the database downloads listed above, each species should have a dedicated folder, so the result should be: Arabidopsis_thaliana     Caenorhabditis_elegans   Physcomitrella_patens  Saccharomyces_cerevisiae   Zea_mays
-Caenorhabditis_briggsae  Drosophila_melanogaster  Populus_trichocarpa    Schizosaccharomyces_pombe. Each folder contains a unique file called "snpEffectPredictor.bin"
+		`ls snpEff/data` # With the database downloads listed above, each species should have a dedicated folder, so the result should display this folder list: Arabidopsis_thaliana, Caenorhabditis_elegans, Physcomitrella_patens, Saccharomyces_cerevisiae, Zea_mays Caenorhabditis_briggsae, Drosophila_melanogaster, Populus_trichocarpa, Schizosaccharomyces_pombe. 
+! **Note 3**: Each folder contains a unique file called "snpEffectPredictor.bin"
 
 To share and distribute you docker image, push your new docker image to dockerhub. You need a dockerhub account (Use Docker hub [documentation] (https://docs.docker.com/docker-hub/)). Then simply push your image on the distant dockerhub server, e.g.:
 	`docker push yourdockerhub_userid/snpeff:yourtag`
-	! *note 1*: the names of your local and your distant repositories should match. You can change the name you give to the local repository at the build step with `docker tag local-image:tagname yourdockerhub_userid/snpeff:tagname`
-	! *note 2*: to be able to push, ensure you are connected to dockerhub: `docker login -u user_id -p <password>` (Use --password-stdin instead of -p to be more secure)
+	! **note 1**: the names of your local and your distant repositories should match. You can change the name you give to the local repository at the build step with `docker tag local-image:tagname yourdockerhub_userid/snpeff:tagname`
+	! **note 2**: to be able to push, ensure you are connected to dockerhub: `docker login -u user_id -p <password>` (Use --password-stdin instead of -p to be more secure)
 
 
-Finally, edit the relevant profiles in nextflow configuration file of your 'Parallel-Variant-Calling' pipeline (in script/nextflow.config), to specify when you would like to use this new docker for snpEff:
-Change this `container = "dockerhub_previous_userid/snpeff:latest"` to this `container = "YOURACCOUNTNAME/snpeff:latest"` (use find ctrl+F and replace)
+Finally, edit the relevant profiles in the nextflow configuration file of your `Parallel-Variant-Calling` pipeline (in `script/nextflow.config`), to specify when you would like to use this new docker for snpEff:
+
+change this `container = "dockerhub_previous_userid/snpeff:latest"` to this `container = "YOURACCOUNTNAME/snpeff:latest"` (use find ctrl+F and replace)

--- a/dockersnpeff/Readme.md
+++ b/dockersnpeff/Readme.md
@@ -76,7 +76,7 @@ To share and distribute your new docker image, push it to dockerhub. You need a 
 
 	`docker push yourdockerhub_userid/snpeff:yourtag`
 
-/!\ **note 1**: the names of your local and your distant repositories should match. You can change the name you give to the local repository at the build step with `docker tag local-image:tagname yourdockerhub_userid/snpeff:tagname`
+/!\ **note 1**: the names of your local and your distant repositories should match. You can change the name you give to the local repository at the build step with: `docker tag local-image:tagname yourdockerhub_userid/snpeff:tagname`
 
 /!\ **note 2**: to be able to push, ensure you are connected to dockerhub: `docker login -u user_id -p <password>` (Use --password-stdin instead of -p to be more secure)
 

--- a/dockersnpeff/Readme.md
+++ b/dockersnpeff/Readme.md
@@ -50,7 +50,7 @@ Provided that Docker (tested for >v20.10.3) is installed on your system, build a
 ```
 docker build -t snpeff:latest . 
 ```
-*#comment: # should be run in this 'dockersnpeff' directory, so that by default Dockerfile is sourced here*
+*#comment: this command should be run in this 'dockersnpeff' directory, so that by default Dockerfile is sourced there*
 
 /!\ **note 1**: do not worry if the terminal prints `ERROR while connecting to ...` (and then mentioning the species database): the database is correctly downloaded however.
 
@@ -63,9 +63,9 @@ docker build -t snpeff:latest .
 	~$:docker run -it snpeff:latest bash 
 *#comment: if needed, replace snpeff:latest by the correct image_name:tag. Your prompt should have changed with something like `root@9fa82673eb90:/myapp#`, indicating that the image container is running*
 ```docker
-	root@9fa82673eb90:/myapp# java -jar snpEff/snpEff.jar -version 
+	root@9fa82673eb90:/myapp# snpeff -version 
 ```
-*#comment: this verifies that the snpEff command is working inside the container*
+*#comment: this verifies that the snpEff command is working inside the container and that the snpeff executable has been successfully added to the $PATH inside the docker*
 
 	$:ls snpEff/data 
 *#comment: With the database downloads listed above, each species should have a dedicated folder, so the result should display this folder list: Arabidopsis_thaliana, Caenorhabditis_elegans, Physcomitrella_patens, Saccharomyces_cerevisiae, Zea_mays Caenorhabditis_briggsae, Drosophila_melanogaster, Populus_trichocarpa, Schizosaccharomyces_pombe*

--- a/dockersnpeff/Readme.md
+++ b/dockersnpeff/Readme.md
@@ -48,25 +48,37 @@ RUN cd snpEff && \
 
 Provided that Docker (tested for >v20.10.3) is installed on your system, build and save the docker image with this command line:
 ```
-docker build -t snpeff:latest . # should be run in this 'dockersnpeff' directory, so that by default Dockerfile is sourced here
+docker build -t snpeff:latest . 
 ```
-! **note 1**: do not worry if the terminal prints "ERROR while connecting to ..." the species database: the database is correctly downloaded however.
+*#comment: # should be run in this 'dockersnpeff' directory, so that by default Dockerfile is sourced here*
 
-! **note 2**: verify that the image has the right content by mounting the container and exploring its content interactively:
-		`docker image list #your new image shoulde appear in the list `
+/!\ **note 1**: do not worry if the terminal prints `ERROR while connecting to ...` (and then mentioning the species database): the database is correctly downloaded however.
 
-		`docker run -it snpeff:latest bash # if needed, replace snpeff:latest by correct image_name:tag. Your prompt should have changed with something like "root@9fa82673eb90:/myapp#", indicating that you are now in the image container`
+/!\ **note 2**: verify that the image has the right content by mounting the container and exploring its content interactively, using the following commands:
 
-		`java -jar snpEff/snpEff.jar -version # verify that snpEff command is working inside the container`
+	~$:docker image list
 
-		`ls snpEff/data # With the database downloads listed above, each species should have a dedicated folder, so the result should display this folder list: Arabidopsis_thaliana, Caenorhabditis_elegans, Physcomitrella_patens, Saccharomyces_cerevisiae, Zea_mays Caenorhabditis_briggsae, Drosophila_melanogaster, Populus_trichocarpa, Schizosaccharomyces_pombe.`
+*#comment: the new image you just built should appear in the list*
+
+	~$:docker run -it snpeff:latest bash 
+*#comment: if needed, replace snpeff:latest by the correct image_name:tag. Your prompt should have changed with something like `root@9fa82673eb90:/myapp#`, indicating that the image container is running*
+```docker
+	root@9fa82673eb90:/myapp# java -jar snpEff/snpEff.jar -version 
+```
+*#comment: this verifies that the snpEff command is working inside the container*
+
+	$:ls snpEff/data 
+*#comment: With the database downloads listed above, each species should have a dedicated folder, so the result should display this folder list: Arabidopsis_thaliana, Caenorhabditis_elegans, Physcomitrella_patens, Saccharomyces_cerevisiae, Zea_mays Caenorhabditis_briggsae, Drosophila_melanogaster, Populus_trichocarpa, Schizosaccharomyces_pombe*
 
 ! **Note 3**: Each folder contains a unique file called `snpEffectPredictor.bin`
 
-To share and distribute you docker image, push your new docker image to dockerhub. You need a dockerhub account (Use Docker hub [documentation] (https://docs.docker.com/docker-hub/)). Then simply push your image on the distant dockerhub server, e.g.:
+To share and distribute your new docker image, push it to dockerhub. You need a dockerhub account (use Docker hub [documentation] (https://docs.docker.com/docker-hub/)). Then simply push your image on the distant dockerhub server, e.g.:
+
 	`docker push yourdockerhub_userid/snpeff:yourtag`
-	! **note 1**: the names of your local and your distant repositories should match. You can change the name you give to the local repository at the build step with `docker tag local-image:tagname yourdockerhub_userid/snpeff:tagname`
-	! **note 2**: to be able to push, ensure you are connected to dockerhub: `docker login -u user_id -p <password>` (Use --password-stdin instead of -p to be more secure)
+
+/!\ **note 1**: the names of your local and your distant repositories should match. You can change the name you give to the local repository at the build step with `docker tag local-image:tagname yourdockerhub_userid/snpeff:tagname`
+
+/!\ **note 2**: to be able to push, ensure you are connected to dockerhub: `docker login -u user_id -p <password>` (Use --password-stdin instead of -p to be more secure)
 
 
-Finally, edit the relevant profiles in the nextflow configuration file of your `Parallel-Variant-Calling` pipeline (in `script/nextflow.config`), to specify when you would like to use this new docker for snpEff. Change this: `container = "dockerhub_previous_userid/snpeff:latest"` to this: `container = "YOURACCOUNTNAME/snpeff:latest"` (use find ctrl+F and replace).
+Finally, edit the relevant profiles in the nextflow configuration file of your `Parallel-Variant-Calling` pipeline (in `script/nextflow.config`), to specify when you would like to use this new snpEff docker. In the code, replace `container = "dockerhub_previous_userid/snpeff:latest"` with: `container = "YOURACCOUNTNAME/snpeff:latest"` (use find ctrl+F and replace).

--- a/script/nextflow.config
+++ b/script/nextflow.config
@@ -103,7 +103,7 @@ profiles {
         cpus = 1
       }
       withLabel: snpeff {
-        container = "romudock/snpeff:latest"
+        container = "fabricebesnard/snpeff:latest"
         executor = "sge"
         cpus = 1
       }
@@ -145,7 +145,7 @@ profiles {
         cpus = 1
       }
       withLabel: snpeff {
-        container = "romudock/snpeff:latest"
+        container = "fabricebesnard/snpeff:latest"
         cpus = 1
       }
             withLabel: cnvnator {
@@ -302,7 +302,7 @@ profiles {
         penv = "openmp32"
       }
       withLabel: snpeff {
-        container = "romudock/snpeff:latest"
+        container = "fabricebesnard/snpeff:latest"
         executor = "sge"
         clusterOptions = "-cwd -V"
         cpus = 1


### PR DESCRIPTION
the docker image for snpEff has been updated to contain all the current useful pre-built databases.
The docker image is now hosted and available here: [fabricebesnard/snpeff](https://hub.docker.com/repository/docker/fabricebesnard/snpeff)